### PR TITLE
Fix README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ Code:
 ```
 //Request MODE 1, PID 0C - RPM
 val pid = PID(ObdModes.MODE_01, "0C")
+pid.formula = "(256A+B)/4" // Engine RPM formula https://en.wikipedia.org/wikiOBD-II_PIDs#Service_01
+pid.bytes="2" // Engine RPM bytes
 val command = OBDCommand(pid)
-command.run(bluetoothSocket.inputStream, bluetoothSocket.outputStream)
-
+command.run(mBtSocket.inputStream, mBtSocket.outputStream)
 Log.d("PID", "${pid.description} : ${pid.calculatedResult}")
 Log.d("PID Formatted Result", command.formattedResult)
 ```


### PR DESCRIPTION
Hi, 

I would first like to thank you for this very useful library.

I started using it with my simulated ECU: https://github.com/spoonieau/OBD2-ECU-Simulator  but I was not getting out the right data, while Torque or other ODB apps were able to get them.

I found that the readme lacked some PID configuration for the command to parse the data.

So before I got this data:
```
2023-12-27 14:15:43.998 29171-30361 PID                     io.xxx.xxx                   D   : 0.0
2023-12-27 14:15:43.998 29171-30361 PID Formatted Result    io.xxx.xxx                   D  0.0 null
2023-12-27 14:15:45.103 29171-30361 PID                     io.xxx.xxx                   D   : 0.0
2023-12-27 14:15:45.103 29171-30361 PID Formatted Result    io.xxx.xxx                   D  0.0 null
```

Then after passing the right parameters to the PID I got ( I configured the simulator to 2000RPM):
```
2023-12-27 15:14:04.268 29162-30222 PID                     io.xxx.xxx                   D   : 2000.0
2023-12-27 15:14:04.268 29162-30222 PID Formatted Result    io.xxx.xxx                   D  2000.0 null
2023-12-27 15:14:05.376 29162-30222 PID                     io.xxx.xxx                   D   : 2000.0
2023-12-27 15:14:05.377 29162-30222 PID Formatted Result    io.xxx.xxx                   D  2000.0 null
2023-12-27 15:14:06.483 29162-30222 PID                     io.xxx.xxx                   D   : 2000.0
```

I hope this will be helpful to other developers using this library.



